### PR TITLE
Soecket option OPT_IFACE_BIND available on iOS and MacOS only

### DIFF
--- a/rtc_base/physical_socket_server.cc
+++ b/rtc_base/physical_socket_server.cc
@@ -333,7 +333,7 @@ int PhysicalSocket::GetOption(Option opt, int* value) {
 int PhysicalSocket::SetOption(Option opt, int value) {
   int slevel;
   int sopt;
-#ifdef __ANDROID__
+#if !defined(WEBRTC_IOS) && !defined(WEBRTC_MAC)
   if(opt == OPT_IFACE_BIND)
     return 0;
 #endif


### PR DESCRIPTION
On Debian 11 socket creation fails

`(turn_port.cc:389): Port[a800fbb0:data:1:0:relay:Net[eth0:10.35.11.x/24:Ethernet:id=1]]: Trying to connect to TURN server via udp @ global.turn.twilio.com:3478
(turn_port.cc:389): Port[a800fbb0:data:1:0:relay:Net[eth0:10.35.11.x/24:Ethernet:id=1]]: Trying to connect to TURN server via udp @ global.turn.twilio.com:3478
(physical_socket_server.cc:243): Binding socket to network interface index 3 failed
(physical_socket_server.cc:243): Binding socket to network interface index 3 failed
(basic_packet_socket_factory.cc:48): UDP bind failed with error 0
(basic_packet_socket_factory.cc:48): UDP bind failed with error 0
(turn_port.cc:393): Failed to create TURN client socket
(turn_port.cc:393): Failed to create TURN client socket`