### PR TITLE
Adjust our changes in Google WebRTC

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -265,9 +265,13 @@ config("common_config") {
   cflags_objc = []
   defines = []
 
-  # UI customization
+  # UI customization, for data channel issue fixing and the max times to retry connecting
   if (rtc_enable_unifi_customization) {
     defines += [ "UI_CUSTOMIZATION" ]
+  }
+  
+  if (rtc_enable_unifi_bitrate_adjustment) {
+    defines += [ "UI_CUSTOMIZED_BITRATE_ADJUSTMENT" ]
   }
 
   if (rtc_enable_protobuf) {

--- a/api/video/video_bitrate_allocation.cc
+++ b/api/video/video_bitrate_allocation.cc
@@ -158,7 +158,7 @@ std::string VideoBitrateAllocation::ToString() const {
       if (si > 0)
         ssb << ",";
       // UI customization - reduce logs to one line
-#ifndef UI_CUSTOMIZATION
+#ifndef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
       ssb << '\n' << "  [";
 #endif
       ssb << "  [";

--- a/api/video/video_bitrate_allocation.h
+++ b/api/video/video_bitrate_allocation.h
@@ -74,7 +74,7 @@ class RTC_EXPORT VideoBitrateAllocation {
   }
 
   // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
   void set_sum_bps(uint32_t bits) {
     sum_ = bits;
   }

--- a/modules/pacing/pacing_controller.h
+++ b/modules/pacing/pacing_controller.h
@@ -162,13 +162,6 @@ class PacingController {
 
   bool IsProbing() const;
 
-  // UI customization
-#ifdef UI_CUSTOMIZATION
-  void SetFrameInterval(int64_t interval) {
-    frame_interval_ = interval;
-  }
-#endif
-
  private:
   TimeDelta UpdateTimeAndGetElapsed(Timestamp now);
   bool ShouldSendKeepalive(Timestamp now) const;
@@ -245,11 +238,6 @@ class PacingController {
   TimeDelta queue_time_limit_;
   bool account_for_audio_;
   bool include_overhead_;
-
-  // UI customization
-#ifdef UI_CUSTOMIZATION
-  int64_t frame_interval_;
-#endif
 };
 }  // namespace webrtc
 

--- a/modules/pacing/task_queue_paced_sender.cc
+++ b/modules/pacing/task_queue_paced_sender.cc
@@ -31,11 +31,6 @@ constexpr const char* kBurstyPacerFieldTrial = "WebRTC-BurstyPacer";
 constexpr const char* kSlackedTaskQueuePacedSenderFieldTrial =
     "WebRTC-SlackedTaskQueuePacedSender";
 
-// UI customization
-#ifdef UI_CUSTOMIZATION
-constexpr const int64_t kSlideWindowSize = 1000;
-#endif
-
 }  // namespace
 
 const int TaskQueuePacedSender::kNoPacketHoldback = -1;
@@ -80,12 +75,7 @@ TaskQueuePacedSender::TaskQueuePacedSender(
       include_overhead_(false),
       task_queue_(task_queue_factory->CreateTaskQueue(
           "TaskQueuePacedSender",
-          TaskQueueFactory::Priority::NORMAL))
-#ifdef UI_CUSTOMIZATION
-      , last_sending_time_(0),
-      accumulate_frames_(0)
-#endif
-      {
+          TaskQueueFactory::Priority::NORMAL)) {
   RTC_DCHECK_GE(max_hold_back_window_, PacingController::kMinSleepTime);
   // There are multiple field trials that can affect burst. If multiple bursts
   // are specified we pick the largest of the values.
@@ -168,24 +158,6 @@ void TaskQueuePacedSender::EnqueuePackets(
     RTC_DCHECK_RUN_ON(&task_queue_);
     TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("webrtc"),
                  "TaskQueuePacedSender::EnqueuePackets");
-
-    // UI customization - for calculating the avg frame interval during 1 sec
-#ifdef UI_CUSTOMIZATION
-    if (!packets.empty() && packets[0]->packet_type() == RtpPacketMediaType::kVideo) {
-      ++accumulate_frames_;
-      int64_t now_ms = rtc::TimeMillis();
-      if (last_sending_time_ > 0) {
-        int64_t interval = now_ms - last_sending_time_;
-        if (interval >= kSlideWindowSize) {
-          auto avg_frame_interval = interval / accumulate_frames_;
-          pacing_controller_.SetFrameInterval(avg_frame_interval);
-          accumulate_frames_ = 0;
-          last_sending_time_ = now_ms;
-        }
-      } else
-        last_sending_time_ = now_ms;
-    }
-#endif
     
     for (auto& packet : packets) {
       TRACE_EVENT2(TRACE_DISABLED_BY_DEFAULT("webrtc"),

--- a/modules/pacing/task_queue_paced_sender.h
+++ b/modules/pacing/task_queue_paced_sender.h
@@ -191,12 +191,6 @@ class TaskQueuePacedSender : public RtpPacketPacer, public RtpPacketSender {
   Stats current_stats_ RTC_GUARDED_BY(stats_mutex_);
 
   rtc::TaskQueue task_queue_;
-
-  // UI customization
-#ifdef UI_CUSTOMIZATION
-  int64_t last_sending_time_;
-  int accumulate_frames_;
-#endif
 };
 }  // namespace webrtc
 #endif  // MODULES_PACING_TASK_QUEUE_PACED_SENDER_H_

--- a/modules/video_coding/utility/frame_dropper.cc
+++ b/modules/video_coding/utility/frame_dropper.cc
@@ -42,7 +42,7 @@ const int kLargeDeltaFactor = 3;
 const float kAccumulatorCapBufferSizeSecs = 3.0f;
 
 // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
 const float kDefaultDecreaseKbps = 100.0f;
 #endif
 }  // namespace
@@ -53,7 +53,7 @@ FrameDropper::FrameDropper()
       drop_ratio_(kDefaultDropRatioAlpha, kDefaultDropRatioValue),
       enabled_(true),
       max_drop_duration_secs_(kDefaultMaxDropDurationSecs)
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
       , reduce_kbits_(0.0f),
       prev_time_ms_(0), 
       expected_bits_per_frame_(0.0f) 
@@ -157,7 +157,7 @@ void FrameDropper::Leak(uint32_t input_framerate) {
     accumulator_ = 0.0f;
   }
   // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
   expected_bits_per_frame_ = expected_bits_per_frame;
 #endif
   UpdateRatio();
@@ -217,7 +217,7 @@ bool FrameDropper::DropFrame() {
     }
     if (drop_count_ < limit) {
       // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
       AccumulateReducedBits();
 #endif
       // As long we are below the limit we should drop frames.
@@ -246,7 +246,7 @@ bool FrameDropper::DropFrame() {
     if (drop_count_ > limit) {
       if (drop_count_ == 0) {
         // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
         AccumulateReducedBits();
 #endif
         // Drop frames when we reset drop_count_.
@@ -280,7 +280,7 @@ void FrameDropper::SetRates(float bitrate, float incoming_frame_rate) {
 }
 
 // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
 void FrameDropper::AccumulateReducedBits() {
   if (expected_bits_per_frame_ > 0)
     reduce_kbits_ += expected_bits_per_frame_;

--- a/modules/video_coding/utility/frame_dropper.h
+++ b/modules/video_coding/utility/frame_dropper.h
@@ -56,7 +56,7 @@ class FrameDropper {
   void SetRates(float bitrate, float incoming_frame_rate);
 
   // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
   void AccumulateReducedBits();
   uint32_t GetReducedBits();
   void ResetReducedBits() {
@@ -98,7 +98,7 @@ class FrameDropper {
   const float max_drop_duration_secs_;
 
   // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
   float reduce_kbits_;
   uint64_t prev_time_ms_;
   float expected_bits_per_frame_;

--- a/video/video_stream_encoder.cc
+++ b/video/video_stream_encoder.cc
@@ -81,15 +81,10 @@ constexpr int kMaxAnimationPixels = 1280 * 720;
 constexpr int kDefaultMinScreenSharebps = 1200000;
 
 // UI customization - const variables for the adaptive bitrate adjustment
-#ifdef UI_CUSTOMIZATION
 // bitrate increase per second
 constexpr uint32_t kDefaultIncreasedBps = 50000;  // 50kbps
 // Min bitrate to enable the adaptive bitrate method
 constexpr uint32_t kBitrateToEnableAdaptive = 1000000;  // 1Mbps
-// The lowbound bitrate for keeping the highest fps
-constexpr uint32_t kMinHighestFpsBitrate = 500000;  // 500kbps
-constexpr uint32_t kLowboundHighestFpsBitrate = kMinHighestFpsBitrate * 8 / 7;
-#endif
 
 bool RequiresEncoderReset(const VideoCodec& prev_send_codec,
                           const VideoCodec& new_send_codec,
@@ -706,12 +701,10 @@ VideoStreamEncoder::VideoStreamEncoder(
           kSwitchEncoderOnInitializationFailuresFieldTrial)),
       vp9_low_tier_core_threshold_(
           ParseVp9LowTierCoreCountThreshold(field_trials)),
-      encoder_queue_(std::move(encoder_queue))
-#ifdef UI_CUSTOMIZATION
-      , prev_encoder_bitrate_bps_(0),
+      encoder_queue_(std::move(encoder_queue)), 
+      prev_encoder_bitrate_bps_(0),
       last_bitrate_adjusted_time_ms_(0),
       init_encoder_bitrate_(false) 
-#endif
       {
   TRACE_EVENT0("webrtc", "VideoStreamEncoder::VideoStreamEncoder");
   RTC_DCHECK_RUN_ON(worker_queue_);
@@ -1296,9 +1289,7 @@ void VideoStreamEncoder::ReconfigureEncoder() {
     rate_settings.rate_control.framerate_fps = GetInputFramerateFps();
 
     SetEncoderRates(UpdateBitrateAllocation(rate_settings));
-#ifdef UI_CUSTOMIZATION
     init_encoder_bitrate_ = true;
-#endif
   }
 
   encoder_stats_observer_->OnEncoderReconfigured(encoder_config_, streams);
@@ -1451,7 +1442,6 @@ void VideoStreamEncoder::OnFrame(Timestamp post_time,
       (cwnd_frame_counter_++ % cwnd_frame_drop_interval_.value() == 0);
 
   // UI customization - never drop frames to avoid artifacts
-#ifdef UI_CUSTOMIZATION
   if (frames_scheduled_for_processing != 1 || cwnd_frame_drop) {
     RTC_LOG(LS_VERBOSE) << "   VideoStreamEncoder::" << __func__
                       << " cwnd_frame_drop=" << cwnd_frame_drop
@@ -1461,7 +1451,6 @@ void VideoStreamEncoder::OnFrame(Timestamp post_time,
     frames_scheduled_for_processing = 1;
     frame_dropper_.AccumulateReducedBits();
   }
-#endif
 
   if (frames_scheduled_for_processing == 1 && !cwnd_frame_drop) {
     MaybeEncodeVideoFrame(incoming_frame, post_time.us());
@@ -1564,19 +1553,8 @@ VideoStreamEncoder::UpdateBitrateAllocation(
   }
 
   // UI customization
-#ifdef UI_CUSTOMIZATION
   auto bitrate_from_estimator = new_rate_settings.rate_control.bitrate.get_sum_bps();
   if (bitrate_from_estimator <= kBitrateToEnableAdaptive) {
-    auto bandwidth_bps = new_rate_settings.rate_control.bandwidth_allocation.bps();
-    if (bitrate_from_estimator < kLowboundHighestFpsBitrate) {
-      if (bandwidth_bps > kLowboundHighestFpsBitrate) {
-        RTC_LOG(LS_INFO) << "[UpdateBitrateAllocation] set bitrate=" << bandwidth_bps << "bps";
-        new_rate_settings.rate_control.bitrate.set_sum_bps(bandwidth_bps);
-      } else {
-        RTC_LOG(LS_INFO) << "[UpdateBitrateAllocation] set bitrate=" << kLowboundHighestFpsBitrate << "bps";
-        new_rate_settings.rate_control.bitrate.set_sum_bps(kLowboundHighestFpsBitrate);
-      }
-    }
     frame_dropper_.ResetReducedBits();
     return new_rate_settings;
   }
@@ -1611,7 +1589,6 @@ VideoStreamEncoder::UpdateBitrateAllocation(
     }
     prev_encoder_bitrate_bps_ = new_rate_settings.rate_control.bitrate.get_sum_bps();
   }
-#endif
 
   return new_rate_settings;
 }
@@ -1779,7 +1756,7 @@ void VideoStreamEncoder::MaybeEncodeVideoFrame(const VideoFrame& video_frame,
     RTC_LOG(LS_VERBOSE) << "   VideoStreamEncoder::" << __func__
                       << "  Too large for target bitrate size="
                       << video_frame.size() << ". Avoid dropping frame";
-#ifndef UI_CUSTOMIZATION
+    /*
     RTC_LOG(LS_INFO) << "Dropping frame. Too large for target bitrate.";
     stream_resource_manager_.OnFrameDroppedDueToSize();
     // Storing references to a native buffer risks blocking frame capture.
@@ -1796,7 +1773,7 @@ void VideoStreamEncoder::MaybeEncodeVideoFrame(const VideoFrame& video_frame,
           VideoStreamEncoderObserver::DropReason::kEncoderQueue);
     }
     return;
-#endif
+    */
 
   }
   stream_resource_manager_.OnMaybeEncodeFrame();
@@ -1838,14 +1815,14 @@ void VideoStreamEncoder::MaybeEncodeVideoFrame(const VideoFrame& video_frame,
                 ? last_encoder_rate_settings_->encoder_target.bps()
                 : 0)
         << ", input frame rate " << framerate_fps;
-  // UI customization, don't actually drop the frame
-#ifndef UI_CUSTOMIZATION
+    // UI customization, don't actually drop the frame
+    /*
     OnDroppedFrame(
         EncodedImageCallback::DropReason::kDroppedByMediaOptimizations);
     accumulated_update_rect_.Union(video_frame.update_rect());
     accumulated_update_rect_is_valid_ &= video_frame.has_update_rect();
     return;
-#endif
+    */
   }
 
   EncodeVideoFrame(video_frame, time_when_posted_us);
@@ -2420,9 +2397,7 @@ void VideoStreamEncoder::ReleaseEncoder() {
   }
   encoder_->Release();
   encoder_initialized_ = false;
-#ifdef UI_CUSTOMIZATION
   init_encoder_bitrate_ = false;
-#endif
   TRACE_EVENT0("webrtc", "VCMGenericEncoder::Release");
 }
 

--- a/video/video_stream_encoder.h
+++ b/video/video_stream_encoder.h
@@ -468,7 +468,7 @@ class VideoStreamEncoder : public VideoStreamEncoderInterface,
   rtc::TaskQueue encoder_queue_;
 
   // UI customization
-#ifdef UI_CUSTOMIZATION
+#ifdef UI_CUSTOMIZED_BITRATE_ADJUSTMENT
   uint32_t prev_encoder_bitrate_bps_;
   uint64_t last_bitrate_adjusted_time_ms_;
   bool init_encoder_bitrate_;

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -230,6 +230,7 @@ declare_args() {
 
   # UI customization
   rtc_enable_unifi_customization = false
+  rtc_enable_unifi_bitrate_adjustment = false
 }
 
 if (!build_with_mozilla) {


### PR DESCRIPTION
As discuss in slack:
1. Add new definition building flag for bitrate adjustment and disable it by default as we've already reduced it by 12.5% in addon.
2. Remove changes in pacing module.