### PR TITLE
[UPC 3714] Bitrate is low in case of good network condition with multiple camera streams.

### DIFF
--- a/modules/congestion_controller/goog_cc/delay_based_bwe.cc
+++ b/modules/congestion_controller/goog_cc/delay_based_bwe.cc
@@ -116,7 +116,15 @@ DelayBasedBwe::Result DelayBasedBwe::IncomingPacketFeedbackVector(
   for (const auto& packet_feedback : packet_feedback_vector) {
     delayed_feedback = false;
     IncomingPacketFeedback(packet_feedback, msg.feedback_time);
+#ifdef UI_CUSTOMIZATION
+    // Just observe sometimes the estimated bitrate will start dropping rapidly when 
+    // the state changes from normal to overuse (0->2), then make a big drop until 
+    // it back to normal, however, the bitrate is becoming too low and becase of no 
+    // probing request, it won't be recovered.
+    if ((prev_detector_state == BandwidthUsage::kBwUnderusing || prev_detector_state == BandwidthUsage::kBwOverusing) &&
+#else
     if (prev_detector_state == BandwidthUsage::kBwUnderusing &&
+#endif
         active_delay_detector_->State() == BandwidthUsage::kBwNormal) {
       recovered_from_overuse = true;
     }

--- a/modules/remote_bitrate_estimator/aimd_rate_control.cc
+++ b/modules/remote_bitrate_estimator/aimd_rate_control.cc
@@ -233,8 +233,13 @@ double AimdRateControl::GetNearMaxIncreaseRateBpsPerSecond() const {
 
   // Approximate the over-use estimator delay to 100 ms.
   TimeDelta response_time = rtt_ + TimeDelta::Millis(100);
+#ifndef UI_CUSTMIZATION
+  // Not quite sure about this part, but looks like it's in experiment
+  // although it's enabled by default. Currently, remove it to make the 
+  // BWE recovered a little faster.
   if (in_experiment_)
     response_time = response_time * 2;
+#endif
   double increase_rate_bps_per_second =
       (avg_packet_size / response_time).bps<double>();
   double kMinIncreaseRateBpsPerSecond = 4000;
@@ -423,6 +428,13 @@ void AimdRateControl::ChangeState(const RateControlInput& input,
         time_last_bitrate_change_ = at_time;
         rate_control_state_ = RateControlState::kRcIncrease;
       }
+#ifdef UI_CUSTMIZATION
+      // if the state is in case of normal, it means the bitrate has dropped to the 
+      // value adapted for current bandwidth, so we can raise it to hold state.
+      else if (rate_control_state_ == RateControlState::kRcDecrease) {
+        rate_control_state_ = RateControlState::kRcHold;
+      }
+#endif
       break;
     case BandwidthUsage::kBwOverusing:
       if (rate_control_state_ != RateControlState::kRcDecrease) {


### PR DESCRIPTION
[Ticket](https://ubiquiti.atlassian.net/browse/UPC-3714)

1. Modify the state machine in AIMD rate control module, and speed up recovery.
2. Recover bitrate more quickly when the bandwidth usage state changed in some cases.