### PR TITLE
No further probing for periodic probes and let bitrate won't drop that fast for better UX.

### DIFF
--- a/modules/congestion_controller/goog_cc/delay_based_bwe.cc
+++ b/modules/congestion_controller/goog_cc/delay_based_bwe.cc
@@ -242,6 +242,10 @@ DelayBasedBwe::Result DelayBasedBwe::MaybeUpdateEstimate(
     if (probe_bitrate) {
       result.probe = true;
       result.updated = true;
+#ifdef UI_BITRATE_RECOVERY
+      // improve the UX, let bitrate won't be dropped that fast
+      if (probe_bitrate->bps() > rate_control_.LatestEstimate().bps())
+#endif
       rate_control_.SetEstimate(*probe_bitrate, at_time);
       result.target_bitrate = rate_control_.LatestEstimate();
     } else {

--- a/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -485,17 +485,21 @@ std::vector<ProbeClusterConfig> ProbeController::Process(Timestamp at_time) {
   uint32_t elapsed_time = 0;
   if (last_probing_time_.ms() > 0)
     elapsed_time = at_time.ms() - last_probing_time_.ms();
+  bool periodic_probe = elapsed_time > kTimeBetweenProbes.ms();
 #endif
   if (TimeForAlrProbe(at_time) || TimeForNetworkStateProbe(at_time)
 #ifdef UI_BITRATE_RECOVERY
-      || elapsed_time > kTimeBetweenProbes.ms()
+      || periodic_probe
 #endif
       ) {
 #ifdef UI_BITRATE_RECOVERY
     last_probing_time_ = at_time;
-#endif
+    return InitiateProbing(
+        at_time, {estimated_bitrate_ * config_.alr_probe_scale}, !periodic_probe);
+#else
     return InitiateProbing(
         at_time, {estimated_bitrate_ * config_.alr_probe_scale}, true);
+#endif
   }
   return std::vector<ProbeClusterConfig>();
 }

--- a/modules/remote_bitrate_estimator/aimd_rate_control.cc
+++ b/modules/remote_bitrate_estimator/aimd_rate_control.cc
@@ -289,12 +289,7 @@ void AimdRateControl::ChangeBitrate(const RateControlInput& input,
       // bitrate increases. We allow a bit more lag at very low rates to not too
       // easily get stuck if the encoder produces uneven outputs.
       DataRate increase_limit =
-#ifdef UI_BITRATE_RECOVERY
-          // just increase the upper bound so that the bitrate will be recovered a little bit quick.
-          2.0 * estimated_throughput + DataRate::KilobitsPerSec(10);
-#else
           1.5 * estimated_throughput + DataRate::KilobitsPerSec(10);
-#endif
       if (ignore_throughput_limit_if_network_estimate_ && network_estimate_ &&
           network_estimate_->link_capacity_upper.IsFinite()) {
         // If we have a Network estimate, we do allow the estimate to increase.


### PR DESCRIPTION
1. Restore changes about increased limit in AIMD control.
2. Currently, we use periodic probing every 5 secs, so if the result of probe is less than current estimated, we use current value instead of the probing result to make sure bitrate won't have a big drop due to our probing.