### PR TITLE
improve: we still need encoder activity detector for effective usage of bitrate

### DIFF
--- a/video/video_send_stream_impl.cc
+++ b/video/video_send_stream_impl.cc
@@ -356,17 +356,12 @@ void VideoSendStreamImpl::StartupVideoSendStream() {
           RTC_DCHECK_RUN_ON(rtp_transport_queue_);
           if (!activity_) {
             if (!timed_out_) {
-#ifndef UI_CUSTOMIZATION_VIDEO_PAUSE
-              // We assume that our encoder is always activity unless it is stopped.
               SignalEncoderTimedOut();
-#endif
             }
             timed_out_ = true;
             disable_padding_ = true;
           } else if (timed_out_) {
-#ifndef UI_CUSTOMIZATION_VIDEO_PAUSE
             SignalEncoderActive();
-#endif
             timed_out_ = false;
           }
           activity_ = false;


### PR DESCRIPTION
1. We still need encoder activity detector for effective usage of bitrate, since it will remove the bitrate allocator in the right situation.
2. Even if it is removed, the `SetRates` will be triggered due to we still send encoded image to lib and CC still works due to there is audio data sending or the forced-probing be activated.