### PR TITLE
fix: [UPC-4055] Google WebRTC media stream often won't resume when returning back to live stream.

### DIFF
--- a/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -501,9 +501,9 @@ std::vector<ProbeClusterConfig> ProbeController::Process(Timestamp at_time) {
     return InitiateProbing(
         at_time, {estimated_bitrate_ * config_.alr_probe_scale}, futher_probe);
 #else
-    if (TimeForAlrProbe(at_time) || TimeForNetworkStateProbe(at_time)) {
-      return InitiateProbing(
-          at_time, {estimated_bitrate_ * config_.alr_probe_scale}, true);
+  if (TimeForAlrProbe(at_time) || TimeForNetworkStateProbe(at_time)) {
+    return InitiateProbing(
+        at_time, {estimated_bitrate_ * config_.alr_probe_scale}, true);
 #endif
   }
   return std::vector<ProbeClusterConfig>();

--- a/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -58,6 +58,10 @@ constexpr TimeDelta kMinTimeBetweenAlrProbes = TimeDelta::Seconds(5);
 // estimate.
 constexpr double kProbeUncertainty = 0.05;
 
+#ifdef UI_BITRATE_RECOVERY
+constexpr TimeDelta kTimeBetweenProbes = TimeDelta::Seconds(5);
+#endif
+
 // Use probing to recover faster after large bitrate estimate drops.
 constexpr char kBweRapidRecoveryExperiment[] =
     "WebRTC-BweRapidRecoveryExperiment";
@@ -199,6 +203,10 @@ std::vector<ProbeClusterConfig> ProbeController::SetBitrates(
         RTC_HISTOGRAM_COUNTS_10000("WebRTC.BWE.MidCallProbing.Initiated",
                                    max_bitrate_.kbps());
 
+#ifdef UI_BITRATE_RECOVERY
+        last_probing_time_ = at_time;
+#endif
+
         return InitiateProbing(at_time, {max_bitrate_}, false);
       }
       break;
@@ -244,6 +252,9 @@ std::vector<ProbeClusterConfig> ProbeController::OnMaxTotalAllocatedBitrate(
       if (second_probe_rate > first_probe_rate)
         probes.push_back(second_probe_rate);
     }
+#ifdef UI_BITRATE_RECOVERY
+    last_probing_time_ = at_time;
+#endif
     return InitiateProbing(at_time, probes,
                            config_.allocation_allow_further_probing.Get());
   }
@@ -280,6 +291,9 @@ std::vector<ProbeClusterConfig> ProbeController::InitiateExponentialProbing(
     probes.push_back(config_.second_exponential_probe_scale.Value() *
                      start_bitrate_);
   }
+#ifdef UI_BITRATE_RECOVERY
+  last_probing_time_ = at_time;
+#endif
   return InitiateProbing(at_time, probes, true);
 }
 
@@ -315,6 +329,9 @@ std::vector<ProbeClusterConfig> ProbeController::SetEstimatedBitrate(
                      << min_bitrate_to_probe_further_;
 
     if (bitrate > min_bitrate_to_probe_further_) {
+#ifdef UI_BITRATE_RECOVERY
+      last_probing_time_ = at_time;
+#endif
       pending_probes = InitiateProbing(
           at_time, {config_.further_exponential_probe_scale * bitrate}, true);
     }
@@ -369,6 +386,7 @@ std::vector<ProbeClusterConfig> ProbeController::RequestProbe(
             (at_time - last_bwe_drop_probing_time_).seconds());
         last_bwe_drop_probing_time_ = at_time;
 #ifdef UI_BITRATE_RECOVERY
+        last_probing_time_ = at_time;
         RTC_LOG(LS_INFO) << "suggested_probe:" << suggested_probe
                          << " min_expected_probe_result:" << min_expected_probe_result
                          << " estimated_bitrate:" << estimated_bitrate_
@@ -462,12 +480,31 @@ std::vector<ProbeClusterConfig> ProbeController::Process(Timestamp at_time) {
   if (estimated_bitrate_.IsZero() || state_ != State::kProbingComplete) {
     return {};
   }
-  if (TimeForAlrProbe(at_time) || TimeForNetworkStateProbe(at_time)) {
 #ifdef UI_BITRATE_RECOVERY
-    RTC_LOG(LS_INFO) << "Start Alr probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
-#endif
+  // Using periodic probing to make sure the bitrate will be recovered quickly
+  uint32_t time_since_last_probing = 0;
+  if (last_probing_time_.ms() > 0)
+    time_since_last_probing = at_time.ms() - last_probing_time_.ms();
+  bool periodic_probe = time_since_last_probing > kTimeBetweenProbes.ms();
+  bool time_for_alr_probe = TimeForAlrProbe(at_time);
+  if (time_for_alr_probe || TimeForNetworkStateProbe(at_time) || periodic_probe) {
+    bool futher_probe = true;
+    // check if we are in alr state(alr checking first), if so, do futher probing.
+    if (time_for_alr_probe) {
+      RTC_LOG(LS_ERROR) << "Start Alr probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
+    } else if (periodic_probe) {
+      // If we aren't in alr state, then for periodic probing, we don't do futher probing.
+      futher_probe = false;
+      RTC_LOG(LS_ERROR) << "Start periodic probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
+    }
+    last_probing_time_ = at_time;
     return InitiateProbing(
-        at_time, {estimated_bitrate_ * config_.alr_probe_scale}, true);
+        at_time, {estimated_bitrate_ * config_.alr_probe_scale}, futher_probe);
+#else
+    if (TimeForAlrProbe(at_time) || TimeForNetworkStateProbe(at_time)) {
+      return InitiateProbing(
+          at_time, {estimated_bitrate_ * config_.alr_probe_scale}, true);
+#endif
   }
   return std::vector<ProbeClusterConfig>();
 }

--- a/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -491,11 +491,11 @@ std::vector<ProbeClusterConfig> ProbeController::Process(Timestamp at_time) {
     bool futher_probe = true;
     // check if we are in alr state(alr checking first), if so, do futher probing.
     if (time_for_alr_probe) {
-      RTC_LOG(LS_ERROR) << "Start Alr probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
+      RTC_LOG(LS_INFO) << "Start Alr probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
     } else if (periodic_probe) {
       // If we aren't in alr state, then for periodic probing, we don't do futher probing.
       futher_probe = false;
-      RTC_LOG(LS_ERROR) << "Start periodic probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
+      RTC_LOG(LS_INFO) << "Start periodic probing, suggested bitrate: " << (estimated_bitrate_ * config_.alr_probe_scale);
     }
     last_probing_time_ = at_time;
     return InitiateProbing(

--- a/modules/congestion_controller/goog_cc/probe_controller.h
+++ b/modules/congestion_controller/goog_cc/probe_controller.h
@@ -175,6 +175,9 @@ class ProbeController {
   int32_t next_probe_cluster_id_ = 1;
 
   ProbeControllerConfig config_;
+#ifdef UI_BITRATE_RECOVERY
+  Timestamp last_probing_time_ = Timestamp::Zero();
+#endif
 };
 
 }  // namespace webrtc

--- a/modules/pacing/bitrate_prober.h
+++ b/modules/pacing/bitrate_prober.h
@@ -80,6 +80,14 @@ class BitrateProber {
   // the last packet in probe. `size` is the total size of all packets in probe.
   void ProbeSent(Timestamp now, DataSize size);
 
+#ifdef UI_BITRATE_RECOVERY
+  // Send probe right away, and change probing state to active.
+  void activateProbe() {
+    next_probe_time_ = Timestamp::MinusInfinity();
+    probing_state_ = ProbingState::kActive;
+  }
+#endif
+
  private:
   enum class ProbingState {
     // Probing will not be triggered in this state at all times.

--- a/modules/pacing/pacing_controller.cc
+++ b/modules/pacing/pacing_controller.cc
@@ -434,6 +434,14 @@ void PacingController::ProcessPackets() {
     std::unique_ptr<RtpPacketToSend> rtp_packet =
         GetPendingPacket(pacing_info, target_send_time, now);
     if (rtp_packet == nullptr) {
+#ifdef UI_BITRATE_RECOVERY
+      // Check if we already have video or audio data, if no, then it is in case 
+      // of a video paused and audio muted situation.
+      // We forced activate bandwidth probing in such case for quickly bitrate
+      // recovery when resuming video.
+      if (!is_probing && data_sent == DataSize::Zero())
+        prober_.activateProbe();
+#endif
       // No packet available to send, check if we should send padding.
       DataSize padding_to_add = PaddingToAdd(recommended_probe_size, data_sent);
       if (padding_to_add > DataSize::Zero()) {


### PR DESCRIPTION
[Ticket](https://ubiquiti.atlassian.net/browse/UPC-4055)

Root cause:
In case of video paused(bitrate below 100kbps) and audio muted, two situations:
1. We aren't in alr state, so probing won't be triggered, bitrate will be recovered slowly so that cause video keep freezing.
2. We are in alr state, but there is no video or audio data sent, so even if a probe request made, no probing packet sent.

Solution:
1. Add a periodic probing, similar to alr probing but a little bit different is whether we want to do further probing. If now is alr probing, then we do further probing as Google did by default, otherwise, just probing once. --> fix situation 1.
2. Forced activate probing in case of video paused and audio muted, it will send a probing packet with about 1 kilobyte which used for bitrate quick recovery. --> fix situation 2.