### PR TITLE
fix: default value should be true for microphone muting.

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -82,6 +82,8 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
   if (self = [super init]) {
     _session = audioSession;
 
+    _isMicrophoneMuted = YES;
+
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center addObserver:self
                selector:@selector(handleInterruptionNotification:)

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -100,6 +100,7 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
     _inputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
     _outputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
     _isMicrophoneEnabled = false;
+    _isMicrophoneMuted = true;
   }
   return self;
 }


### PR DESCRIPTION
fix: the default value of iOS microphone muting flag is incorrect.