### PR TITLE
feat: [UPC-4333] Enable/disable video suspending for each stream respectively.

### DIFF
--- a/api/rtp_parameters.h
+++ b/api/rtp_parameters.h
@@ -705,11 +705,14 @@ struct RTC_EXPORT RtpParameters {
   // indicates which is preferred. Only for video tracks.
   absl::optional<DegradationPreference> degradation_preference;
 
+  bool suspend_below_min_bitrate = false;
+
   bool operator==(const RtpParameters& o) const {
     return mid == o.mid && codecs == o.codecs &&
            header_extensions == o.header_extensions &&
            encodings == o.encodings && rtcp == o.rtcp &&
-           degradation_preference == o.degradation_preference;
+           degradation_preference == o.degradation_preference &&
+           suspend_below_min_bitrate == o.suspend_below_min_bitrate;
   }
   bool operator!=(const RtpParameters& o) const { return !(*this == o); }
 };

--- a/call/bitrate_allocator.cc
+++ b/call/bitrate_allocator.cc
@@ -562,6 +562,17 @@ int BitrateAllocator::GetStartBitrate(
   }
 }
 
+void BitrateAllocator::SuspendBelowMinBitrate(BitrateAllocatorObserver* observer, 
+    bool suspend_below_min_bitrate) {
+  RTC_DCHECK_RUN_ON(&sequenced_checker_);
+  auto it = absl::c_find_if(
+      allocatable_tracks_,
+      [observer](const auto& config) { return config.observer == observer; });
+  if (it != allocatable_tracks_.end()) {
+    it->config.enforce_min_bitrate = !suspend_below_min_bitrate;
+  }
+}
+
 uint32_t bitrate_allocator_impl::AllocatableTrack::LastAllocatedBitrate()
     const {
   // Return the configured minimum bitrate for newly added observers, to avoid

--- a/call/bitrate_allocator.h
+++ b/call/bitrate_allocator.h
@@ -71,6 +71,9 @@ class BitrateAllocatorInterface {
   virtual void RemoveObserver(BitrateAllocatorObserver* observer) = 0;
   virtual int GetStartBitrate(BitrateAllocatorObserver* observer) const = 0;
 
+  virtual void SuspendBelowMinBitrate(BitrateAllocatorObserver* observer, 
+                                      bool suspend_below_min_bitrate) {}
+
  protected:
   virtual ~BitrateAllocatorInterface() = default;
 };
@@ -135,6 +138,9 @@ class BitrateAllocator : public BitrateAllocatorInterface {
   // Returns initial bitrate allocated for `observer`. If `observer` is not in
   // the list of added observers, a best guess is returned.
   int GetStartBitrate(BitrateAllocatorObserver* observer) const override;
+
+  void SuspendBelowMinBitrate(BitrateAllocatorObserver* observer, 
+                              bool suspend_below_min_bitrate) override;
 
  private:
   using AllocatableTrack = bitrate_allocator_impl::AllocatableTrack;

--- a/call/video_send_stream.h
+++ b/call/video_send_stream.h
@@ -255,6 +255,8 @@ class VideoSendStream {
 
   virtual void GenerateKeyFrame(const std::vector<std::string>& rids) = 0;
 
+  virtual void SuspendBelowMinBitrate(bool suspend_below_min_bitrate) {}
+
  protected:
   virtual ~VideoSendStream() {}
 };

--- a/media/engine/webrtc_video_engine.cc
+++ b/media/engine/webrtc_video_engine.cc
@@ -2376,6 +2376,12 @@ webrtc::RTCError WebRtcVideoChannel::WebRtcVideoSendStream::SetRtpParameters(
       stream_->SetSource(source_, GetDegradationPreference());
     }
   }
+  // UI Customization
+  parameters_.config.suspend_below_min_bitrate =
+      rtp_parameters_.suspend_below_min_bitrate;
+  if (stream_)
+    stream_->SuspendBelowMinBitrate(rtp_parameters_.suspend_below_min_bitrate);
+
   return webrtc::RTCError::OK();
 }
 

--- a/modules/congestion_controller/goog_cc/delay_based_bwe.cc
+++ b/modules/congestion_controller/goog_cc/delay_based_bwe.cc
@@ -227,6 +227,10 @@ DelayBasedBwe::Result DelayBasedBwe::MaybeUpdateEstimate(
         rate_control_.TimeToReduceFurther(at_time, *acked_bitrate)) {
       result.updated =
           UpdateEstimate(at_time, acked_bitrate, &result.target_bitrate);
+#ifdef UI_BITRATE_RECOVERY
+      RTC_LOG(LS_INFO) << "MaybeUpdateEstimate: Bandwidth overusing,"
+                       << " target_bitrate=" << result.target_bitrate.bps();
+#endif
     } else if (!acked_bitrate && rate_control_.ValidEstimate() &&
                rate_control_.InitialTimeToReduceFurther(at_time)) {
       // Overusing before we have a measured acknowledged bitrate. Reduce send
@@ -237,6 +241,10 @@ DelayBasedBwe::Result DelayBasedBwe::MaybeUpdateEstimate(
       result.updated = true;
       result.probe = false;
       result.target_bitrate = rate_control_.LatestEstimate();
+#ifdef UI_BITRATE_RECOVERY
+      RTC_LOG(LS_INFO) << "MaybeUpdateEstimate: Bandwidth overusing before we have a measured acknowledged bitrate,"
+                       << " target_bitrate=" << result.target_bitrate.bps();
+#endif
     }
   } else {
     if (probe_bitrate) {

--- a/modules/pacing/bitrate_prober.h
+++ b/modules/pacing/bitrate_prober.h
@@ -80,13 +80,13 @@ class BitrateProber {
   // the last packet in probe. `size` is the total size of all packets in probe.
   void ProbeSent(Timestamp now, DataSize size);
 
-#ifdef UI_BITRATE_RECOVERY
-  // Send probe right away, and change probing state to active.
-  void activateProbe() {
-    next_probe_time_ = Timestamp::MinusInfinity();
-    probing_state_ = ProbingState::kActive;
-  }
-#endif
+// #ifdef UI_BITRATE_RECOVERY
+//   // Send probe right away, and change probing state to active.
+//   void activateProbe() {
+//     next_probe_time_ = Timestamp::MinusInfinity();
+//     probing_state_ = ProbingState::kActive;
+//   }
+// #endif
 
  private:
   enum class ProbingState {

--- a/modules/pacing/pacing_controller.cc
+++ b/modules/pacing/pacing_controller.cc
@@ -434,14 +434,14 @@ void PacingController::ProcessPackets() {
     std::unique_ptr<RtpPacketToSend> rtp_packet =
         GetPendingPacket(pacing_info, target_send_time, now);
     if (rtp_packet == nullptr) {
-#ifdef UI_BITRATE_RECOVERY
+// #ifdef UI_BITRATE_RECOVERY
       // Check if we already have video or audio data, if no, then it is in case 
       // of a video paused and audio muted situation.
       // We forced activate bandwidth probing in such case for quickly bitrate
       // recovery when resuming video.
-      if (!is_probing && data_sent == DataSize::Zero())
-        prober_.activateProbe();
-#endif
+//       if (!is_probing && data_sent == DataSize::Zero())
+//         prober_.activateProbe();
+// #endif
       // No packet available to send, check if we should send padding.
       DataSize padding_to_add = PaddingToAdd(recommended_probe_size, data_sent);
       if (padding_to_add > DataSize::Zero()) {

--- a/video/video_send_stream.cc
+++ b/video/video_send_stream.cc
@@ -364,5 +364,13 @@ void VideoSendStream::GenerateKeyFrame(const std::vector<std::string>& rids) {
   }
 }
 
+void VideoSendStream::SuspendBelowMinBitrate(bool suspend_below_min_bitrate) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  rtp_transport_queue_->RunOrPost(
+      SafeTask(transport_queue_safety_, [this, suspend_below_min_bitrate] {
+        send_stream_.SuspendBelowMinBitrate(suspend_below_min_bitrate);
+      }));
+}
+
 }  // namespace internal
 }  // namespace webrtc

--- a/video/video_send_stream.h
+++ b/video/video_send_stream.h
@@ -96,6 +96,8 @@ class VideoSendStream : public webrtc::VideoSendStream {
                                       RtpPayloadStateMap* payload_state_map);
   void GenerateKeyFrame(const std::vector<std::string>& rids) override;
 
+  void SuspendBelowMinBitrate(bool suspend_below_min_bitrate) override;
+
  private:
   friend class test::VideoSendStreamPeer;
 

--- a/video/video_send_stream_impl.h
+++ b/video/video_send_stream_impl.h
@@ -92,6 +92,8 @@ class VideoSendStreamImpl : public webrtc::BitrateAllocatorObserver,
     return configured_pacing_factor_;
   }
 
+  void SuspendBelowMinBitrate(bool suspend_below_min_bitrate);
+
  private:
   // Implements BitrateAllocatorObserver.
   uint32_t OnBitrateUpdated(BitrateAllocationUpdate update) override;
@@ -156,6 +158,7 @@ class VideoSendStreamImpl : public webrtc::BitrateAllocatorObserver,
   uint32_t encoder_max_bitrate_bps_;
   uint32_t encoder_target_rate_bps_;
   double encoder_bitrate_priority_;
+  bool suspend_below_min_bitrate_;
 
   VideoStreamEncoderInterface* const video_stream_encoder_;
 


### PR DESCRIPTION
[Ticket](https://ubiquiti.atlassian.net/browse/UPC-4333)

1. Add interface for setting video suspended to each stream.
2. Remove probes without sending video and audio data.