### PR TITLE
[UPC-4887] Upgrade Google WebRTC to M113

### DIFF
--- a/call/call.h
+++ b/call/call.h
@@ -153,7 +153,7 @@ class Call {
   virtual TaskQueueBase* worker_thread() const = 0;
 
 #ifdef UI_CUSTOMIZED_AUDIO_STREAM_API
-  virtual RtpStreamReceiverController* receiver_controller() = 0;
+    virtual RtpStreamReceiverController* receiver_controller() { return nullptr; }
 #endif
 
   virtual ~Call() {}

--- a/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -229,8 +229,11 @@ std::vector<ProbeClusterConfig> ProbeController::OnMaxTotalAllocatedBitrate(
       state_ == State::kProbingComplete &&
       max_total_allocated_bitrate != max_total_allocated_bitrate_ &&
       estimated_bitrate_ < max_bitrate_ &&
-      estimated_bitrate_ < max_total_allocated_bitrate &&
-      allow_allocation_probe) {
+      estimated_bitrate_ < max_total_allocated_bitrate
+#ifndef UI_BITRATE_RECOVERY
+      && allow_allocation_probe
+#endif
+      ) {
     max_total_allocated_bitrate_ = max_total_allocated_bitrate;
 
     if (!config_.first_allocation_probe_scale)

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -168,11 +168,17 @@ if (is_ios || is_mac) {
 
     if (is_ios) {
       sources += [
-        "objc/helpers/RTCCameraPreviewView.h",
-        "objc/helpers/RTCCameraPreviewView.m",
         "objc/helpers/UIDevice+RTCDevice.h",
         "objc/helpers/UIDevice+RTCDevice.mm",
       ]
+# UI Customization Begin
+      if (ios_device_name != "appletv") {
+        sources += [
+          "objc/helpers/RTCCameraPreviewView.h",
+          "objc/helpers/RTCCameraPreviewView.m",
+        ]
+      }
+# UI Customization End
       frameworks += [ "UIKit.framework" ]
     }
   }
@@ -667,11 +673,26 @@ if (is_ios || is_mac) {
       visibility = [ "*" ]
       allow_poison = [ "audio_codecs" ]  # TODO(bugs.webrtc.org/8396): Remove.
       sources = [
-        "objc/components/capturer/RTCCameraVideoCapturer.h",
-        "objc/components/capturer/RTCCameraVideoCapturer.m",
         "objc/components/capturer/RTCFileVideoCapturer.h",
         "objc/components/capturer/RTCFileVideoCapturer.m",
       ]
+# UI Customization Begin
+      if (is_ios) {
+        if (ios_device_name != "appletv") {
+          sources += [
+              "objc/components/capturer/RTCCameraVideoCapturer.h",
+              "objc/components/capturer/RTCCameraVideoCapturer.m",
+          ]
+        }
+      }
+      
+      if (is_mac) {
+        sources += [
+            "objc/components/capturer/RTCCameraVideoCapturer.h",
+            "objc/components/capturer/RTCCameraVideoCapturer.m",
+        ]
+      }
+# UI Customization End
       frameworks = [
         "AVFoundation.framework",
         "CoreVideo.framework",

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  * cleanups.
  */
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (BOOL)addRenderingDestination:(__kindof UIView *)view;
 #else
 - (BOOL)addRenderingDestination:(__kindof NSView *)view;

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
@@ -143,7 +143,7 @@ static const NSInteger kMaxInflightBuffers = 1;
 // UIView define : @property(nonatomic,getter=isOpaque) BOOL opaque;
     view.opaque = false;
 #endif
-    view.opaque = false;
+
     view.clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 0.0);
       // UI Customization End
     [self loadAssets];


### PR DESCRIPTION
## Ticket : [[UPC-4887]](https://ubiquiti.atlassian.net/browse/UPC-4887)
## Description :
1. fixed apple tvOS platform check issue.
2. fixed cxx17 to cxx20 issue.
3. fixed UI_BITRATE_RECOVERY lost.

## Before this PR :
- appletv build fail.
- DebianServer Backend build  pure virtual function and function arguments.
- appleTV RTCMTLRenderer.h Method Platform define issue.

## After this PR :
Success Ubiquiti All Support Platform : 
- macOS arm64/x86_64
- iOS arm64 / 
- iOS Simulate arm64 / x86_64
- tvOS arm64
- tvOS Simulate arm64 / x86_64
- macOSCatalys arm64 / x86_64 (iOS SDK Framework can run on macOS platform, but macOS Project can use.)
- Android armeabi-v7a / arm64-v8a / x86 / x86_64
- Debian arm64 / x86_64
- Ubuntu

## Related PR :
None

## TBD :
None

[UPC-4887]: https://ubiquiti.atlassian.net/browse/UPC-4887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ