### PR TITLE
Update Jenksinfile.pdx support build macOS and iOS

### DIFF
--- a/Jenkinsfile.pdx
+++ b/Jenkinsfile.pdx
@@ -1,5 +1,57 @@
 def APP = 'googlewebrtc'
 
+def doAndroidAll='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+make WEBRTC_BRANCH=$TAG_NAME artifactory
+'''
+
+def doUbuntuAmd64='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+make WEBRTC_PLATFORM=Ubuntu WEBRTC_BRANCH=$TAG_NAME artifactory
+'''
+
+def doDebianAmd64='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+make WEBRTC_PLATFORM=Debian DEBIAN_TARGET_ARCH=x86_64 WEBRTC_BRANCH=$TAG_NAME artifactory
+'''
+
+def doDebianArm64='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+make WEBRTC_PLATFORM=Debian DEBIAN_TARGET_ARCH=aarch64 WEBRTC_BRANCH=$TAG_NAME artifactory
+'''
+
+def doiOSBuild='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+export BranchName=${BRANCH}
+export TAG_NAME=${TAG_NAME}
+./generic_xcframework.sh $TAG_NAME
+'''
+
+def doMacOSBuild='''
+env
+git clean -dxff
+git clone https://$GITTOKEN@github.com/ubiquiti/libjingle-build
+cd libjingle-build
+export BranchName=${BRANCH}
+export TAG_NAME=${TAG_NAME}
+./generic_xcframework_macOS.sh $TAG_NAME
+'''
+
 def HASH
 def BRANCH
 def TAG_NAME
@@ -26,60 +78,162 @@ pipeline {
         ARTIFACTORY_CREDS=credentials('ARTIFACTORY_CREDS')
         ARTIFACTORY_CENTRALIZED_UPLOAD='yes'
         GITHUB_READ_FILE_TOKEN=credentials('GITHUB_READ_FILE_TOKEN')
+        CREDS_ID='karlis.ogsts'
+        GITTOKEN=credentials("${env.CREDS_ID}")
     }
 
     options {
         skipDefaultCheckout true
     }
 
-
     stages {
-    
-        stage('Prepare') {
+        stage('Checkout') {
             steps {
+
+                deleteDir()
+
+                checkout scm
+
                 script {
-                    BUILD_DATE = sh(returnStdout: true, script: 'date -u +\'%Y-%m-%dT%H:%M:%SZ\'').trim()
-                    BRANCH = env.BRANCH_NAME
-                    TAG_NAME = env.TAG_NAME
-                    if (BRANCH.startsWith('origin/')) BRANCH = BRANCH.substring('origin/'.length())
+                      BUILD_DATE = sh(returnStdout: true, script: 'date -u +\'%Y-%m-%dT%H:%M:%SZ\'').trim()
+                      BRANCH = env.BRANCH_NAME
+                      TAG_NAME = env.TAG_NAME
+                      HASH = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(8)
+                      if (BRANCH.startsWith('origin/')) BRANCH = BRANCH.substring('origin/'.length())
                 }
+
+                stash(includes: '**/*', name: 'workspace', useDefaultExcludes: false)
             }
         }
     
+        stage('Prepare Docker') {
+            steps {
+                parallel(
+                    'docker:arm64': {
+                        script {
+                            DOCKER_ARM64 = docker.build("${APP}_arm64:${HASH}", "--pull -f ./docker/Dockerfile.debian.11.arm64 ./docker")
+                        }
+                    },
+                    'docker:amd64': {
+                        script {
+                            DOCKER_AMD64 = docker.build("${APP}_amd64:${HASH}", "--pull -f ./docker/Dockerfile.debian.11.amd64 ./docker")
+                        }
+                    },
+                    'docker:ubuntu_22_04_amd64': {
+                        script {
+                            DOCKER_UBUNTU_22_04_AMD64 = docker.build("${APP}_ubuntu_22_04_amd64:${HASH}", "--pull -f ./docker/Dockerfile.ubuntu.22.04.amd64 ./docker")
+                        }
+                    }
+                )
+            }
+        }
+
         stage('Build') {
             parallel {
-                stage('MacOS') {
+                stage('AndroidBuild') {
                     stages {
-                        stage('Checkout') {
+                       stage('Android All Library') {
                             steps {
-                                node(label: 'rix-macos-amd64') {
-                    deleteDir()
-                    checkout([$class : 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: scm.userRemoteConfigs[0].credentialsId, url: 'https://github.com/ubiquiti/libjingle-build']]])
-                                }
-                            }
-                        }
-                        
-                        stage('MacOS build') {
-                            steps {
-                                node(label: 'rix-macos-amd64') {
-                                    sh label: 'build', script: "export BranchName=${BRANCH} && \
-                                    export TAG_NAME=${TAG_NAME} && \
-                                    ./generic_xcframework_macOS.sh"
-                                }
-                            }
-                        }
-                        
-                       stage('iOS build') {
-                            steps {
-                                node(label: 'rix-macos-amd64') {
-                                    sh label: 'build', script: "export BranchName=${BRANCH} && \
-                                    export TAG_NAME=${TAG_NAME} && \
-                                    ./generic_xcframework.sh"
+                                node('docker') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        DOCKER_UBUNTU_22_04_AMD64.inside() {
+                                            sh label: 'build', script: "${doAndroidAll}"
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                
+                stage('UbuntuBuild') {
+                    stages {
+                       stage('Ubuntu Amd64 Library') {
+                            steps {
+                                node('docker') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        DOCKER_UBUNTU_22_04_AMD64.inside() {
+                                            sh label: 'build', script: "${doUbuntuAmd64}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                stage('Debian 11 Arm64') {
+                    stages {
+                        stage('Debian Aarm64 Library') {
+                            steps {
+                                node('docker') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        DOCKER_ARM64.inside() {
+                                            sh label: 'build', script: "${doDebianArm64}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                stage('Debian 11 Amd64') {
+                    stages {
+                        stage('Debian Amd64 Library') {
+                            steps {
+                                node('docker') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        DOCKER_AMD64.inside() {
+                                            sh label: 'build', script: "${doDebianAmd64}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                stage('iOS Build') {
+                    stages {
+                        stage('iOS Library') {
+                            steps {
+                                node(label: 'rix-macos-arm64') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        sh label: 'build', script: "${doiOSBuild}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                                    
+                stage('MacOS Build') {
+                    stages {
+                        stage('MacOS Library') {
+                            steps {
+                                node(label: 'rix-macos-amd64') {
+                                    deleteDir()
+                                    unstash 'workspace'
+                                    script {
+                                        sh label: 'build', script: "${doMacOSBuild}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
             }
         }
     }

--- a/Jenkinsfile.pdx
+++ b/Jenkinsfile.pdx
@@ -38,10 +38,10 @@ pipeline {
         stage('Prepare') {
             steps {
                 script {
-                      BUILD_DATE = sh(returnStdout: true, script: 'date -u +\'%Y-%m-%dT%H:%M:%SZ\'').trim()
-                      BRANCH = env.BRANCH_NAME
-                      TAG_NAME = env.TAG_NAME
-                      if (BRANCH.startsWith('origin/')) BRANCH = BRANCH.substring('origin/'.length())
+                    BUILD_DATE = sh(returnStdout: true, script: 'date -u +\'%Y-%m-%dT%H:%M:%SZ\'').trim()
+                    BRANCH = env.BRANCH_NAME
+                    TAG_NAME = env.TAG_NAME
+                    if (BRANCH.startsWith('origin/')) BRANCH = BRANCH.substring('origin/'.length())
                 }
             }
         }
@@ -53,8 +53,8 @@ pipeline {
                         stage('Checkout') {
                             steps {
                                 node(label: 'rix-macos-amd64') {
-					deleteDir()
-					checkout([$class : 'GitSCM', branches: [[name: '*/feature/jenkins-build']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: scm.userRemoteConfigs[0].credentialsId, url: 'https://github.com/ubiquiti/libjingle-build']]])
+                    deleteDir()
+                    checkout([$class : 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: scm.userRemoteConfigs[0].credentialsId, url: 'https://github.com/ubiquiti/libjingle-build']]])
                                 }
                             }
                         }
@@ -62,7 +62,19 @@ pipeline {
                         stage('MacOS build') {
                             steps {
                                 node(label: 'rix-macos-amd64') {
-                                    sh label: 'build', script: "sh BRANCH=${BRANCH} TAG_NAME=${TAG_NAME} generic_xcframework.sh"
+                                    sh label: 'build', script: "export BranchName=${BRANCH} && \
+                                    export TAG_NAME=${TAG_NAME} && \
+                                    ./generic_xcframework_macOS.sh"
+                                }
+                            }
+                        }
+                        
+                       stage('iOS build') {
+                            steps {
+                                node(label: 'rix-macos-amd64') {
+                                    sh label: 'build', script: "export BranchName=${BRANCH} && \
+                                    export TAG_NAME=${TAG_NAME} && \
+                                    ./generic_xcframework.sh"
                                 }
                             }
                         }

--- a/docker/Dockerfile.debian.11.amd64
+++ b/docker/Dockerfile.debian.11.amd64
@@ -1,0 +1,110 @@
+# syntax=docker/dockerfile:experimental
+FROM debian:bullseye
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LC_ALL=C LANGUAGE=C LANG=C
+
+ENV OS_NAME=Debian
+ENV OS_VERSION=11
+ENV OS_ARCH=x86_64
+ENV ARTIFACTORY_URL="https://pdx-artifacts.rad.ubnt.com"
+
+ARG HOST_UID=1002
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    useradd -u $HOST_UID --create-home --shell /bin/bash ubnt
+
+RUN \
+    sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g' && \
+    echo "ubnt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "ubnt user:";  su - ubnt -c id
+
+RUN dpkg --configure -a
+
+RUN apt-get update && apt-get install -qy apt-utils gnupg2
+
+RUN printf "installing packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-utils \
+    autoconf \
+    automake \
+    binfmt-support \
+    build-essential \
+    curl \
+    fakeroot \
+    procps \
+    git \
+    gnupg2 \
+    wget
+
+RUN printf "installing dev packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsystemd-dev \
+    libbluetooth-dev \
+    libudev-dev
+
+RUN printf "installing python...\n" && \
+    apt-get update && apt-get install -y --no-install-recommends python2.7 && \
+    ln -sf /usr/bin/python2.7 /usr/bin/python
+
+RUN apt-get install -y --no-install-recommends \
+	jq \
+	lsb-release \
+	sshpass \
+	pkg-config
+
+RUN apt-get install -y --no-install-recommends \
+	bc \
+	bzip2 \
+	ca-certificates \
+	cpio \
+	file \
+	git \
+	gzip \
+	libncurses5-dev \
+	make \
+	openssh-client \
+	python \
+	python3 \
+	rsync \
+	unzip \
+	wget \
+	asciidoc \
+	cmake \
+	lzip \
+	tar \
+	xz-utils \
+	eatmydata \
+	uidmap \
+	xxd \
+	vim \
+	ninja-build \
+	curl \
+	autoconf \
+	autotools-dev \
+	sudo \
+	automake \
+	libtool \
+	ant \
+	openjdk-17-jdk \
+	nasm \
+	tree \
+	pip \
+	python-setuptools
+
+RUN wget https://releases.jfrog.io/artifactory/jfrog-cli/v2/[RELEASE]/jfrog-cli-linux-amd64/jfrog -O /usr/local/bin/jfrog && sudo chmod a+x /usr/local/bin/jfrog
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+WORKDIR /build
+USER ubnt
+ENV HOME=/home/ubnt
+RUN printf "installing nvm...\n" && \
+	curl https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash
+ENV NVM_DIR="$HOME/.nvm"
+RUN \. "$NVM_DIR/nvm.sh" && \. "$NVM_DIR/bash_completion"
+ENV NVM_ENV_SH=$HOME/.nvm/nvm.sh

--- a/docker/Dockerfile.debian.11.arm64
+++ b/docker/Dockerfile.debian.11.arm64
@@ -1,0 +1,118 @@
+# syntax=docker/dockerfile:experimental
+FROM debian:bullseye
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LC_ALL=C LANGUAGE=C LANG=C
+
+ENV OS_NAME=Debian
+ENV OS_VERSION=11
+ENV OS_ARCH=aarch64
+ENV ARTIFACTORY_URL="https://pdx-artifacts.rad.ubnt.com"
+
+ARG HOST_UID=1002
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    useradd -u $HOST_UID --create-home --shell /bin/bash ubnt
+
+RUN \
+    sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g' && \
+    echo "ubnt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "ubnt user:";  su - ubnt -c id
+
+RUN dpkg --configure -a
+
+RUN apt-get update && apt-get install -qy apt-utils gnupg2
+
+RUN printf "adding arm64 to dpkg...\n" && \
+    dpkg --add-architecture arm64
+
+RUN printf "installing packages...\n" && \
+    apt-get update && \
+    apt-get install -y crossbuild-essential-arm64 && \
+    apt-get install -y --no-install-recommends \
+    apt-utils \
+    autoconf \
+    automake \
+    binfmt-support \
+    build-essential \
+    curl \
+    fakeroot \
+    procps \
+    git \
+    qemu-user-static \
+    gnupg2 \
+    wget
+
+RUN printf "installing dev packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsystemd-dev:arm64 \
+    libbluetooth-dev:arm64 \
+    libudev-dev:arm64
+
+RUN printf "installing python...\n" && \
+    apt-get update && apt-get install -y --no-install-recommends python2.7 && \
+    ln -sf /usr/bin/python2.7 /usr/bin/python
+
+RUN apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu \
+	g++-aarch64-linux-gnu \
+	binutils-aarch64-linux-gnu \
+	jq \
+	lsb-release \
+	sshpass \
+	pkg-config
+
+RUN apt-get install -y --no-install-recommends \
+	bc \
+	bzip2 \
+	ca-certificates \
+	cpio \
+	file \
+	git \
+	gzip \
+	libncurses5-dev \
+	make \
+	openssh-client \
+	python \
+	python3 \
+	rsync \
+	unzip \
+	wget \
+	asciidoc \
+	cmake \
+	lzip \
+	tar \
+	xz-utils \
+	eatmydata \
+	uidmap \
+	xxd \
+	vim \
+	ninja-build \
+	curl \
+	autoconf \
+	autotools-dev \
+	sudo \
+	automake \
+	libtool \
+	ant \
+	openjdk-17-jdk \
+	nasm \
+	tree \
+	pip \
+	python-setuptools
+
+RUN wget https://releases.jfrog.io/artifactory/jfrog-cli/v2/[RELEASE]/jfrog-cli-linux-amd64/jfrog -O /usr/local/bin/jfrog && sudo chmod a+x /usr/local/bin/jfrog
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+WORKDIR /build
+USER ubnt
+ENV HOME=/home/ubnt
+RUN printf "installing nvm...\n" && \
+    curl https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash
+ENV NVM_DIR="$HOME/.nvm"
+RUN \. "$NVM_DIR/nvm.sh" && \. "$NVM_DIR/bash_completion"
+ENV NVM_ENV_SH=$HOME/.nvm/nvm.sh

--- a/docker/Dockerfile.ubuntu.20.04.amd64
+++ b/docker/Dockerfile.ubuntu.20.04.amd64
@@ -1,0 +1,110 @@
+# syntax=docker/dockerfile:experimental
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LC_ALL=C LANGUAGE=C LANG=C
+
+ENV OS_NAME=Ubuntu
+ENV OS_VERSION=20.04
+ENV OS_ARCH=x86_64
+ENV ARTIFACTORY_URL="https://pdx-artifacts.rad.ubnt.com"
+
+ARG HOST_UID=1002
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    useradd -u $HOST_UID --create-home --shell /bin/bash ubnt
+
+RUN \
+    sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g' && \
+    echo "ubnt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "ubnt user:";  su - ubnt -c id
+
+RUN dpkg --configure -a
+
+RUN apt-get update && apt-get install -qy apt-utils gnupg2
+
+RUN printf "installing packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-utils \
+    autoconf \
+    automake \
+    binfmt-support \
+    build-essential \
+    curl \
+    fakeroot \
+    procps \
+    git \
+    gnupg2 \
+    wget
+
+RUN printf "installing dev packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsystemd-dev \
+    libbluetooth-dev \
+    libudev-dev
+
+RUN printf "installing python...\n" && \
+    apt-get update && apt-get install -y --no-install-recommends python2.7 && \
+    ln -sf /usr/bin/python2.7 /usr/bin/python
+
+RUN apt-get install -y --no-install-recommends \
+	jq \
+	lsb-release \
+	sshpass \
+	pkg-config
+
+RUN apt-get install -y --no-install-recommends \
+	bc \
+	bzip2 \
+	ca-certificates \
+	cpio \
+	file \
+	git \
+	gzip \
+	libncurses5-dev \
+	make \
+	openssh-client \
+	python \
+	python3 \
+	rsync \
+	unzip \
+	wget \
+	asciidoc \
+	cmake \
+	lzip \
+	tar \
+	xz-utils \
+	eatmydata \
+	uidmap \
+	xxd \
+	vim \
+	ninja-build \
+	curl \
+	autoconf \
+	autotools-dev \
+	sudo \
+	automake \
+	libtool \
+	ant \
+	openjdk-17-jdk \
+	nasm \
+	tree \
+	pip \
+	python-setuptools
+
+RUN wget https://releases.jfrog.io/artifactory/jfrog-cli/v2/[RELEASE]/jfrog-cli-linux-amd64/jfrog -O /usr/local/bin/jfrog && sudo chmod a+x /usr/local/bin/jfrog
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+WORKDIR /build
+USER ubnt
+ENV HOME=/home/ubnt
+RUN printf "installing nvm...\n" && \
+	curl https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash
+ENV NVM_DIR="$HOME/.nvm"
+RUN \. "$NVM_DIR/nvm.sh" && \. "$NVM_DIR/bash_completion"
+ENV NVM_ENV_SH=$HOME/.nvm/nvm.sh

--- a/docker/Dockerfile.ubuntu.22.04.amd64
+++ b/docker/Dockerfile.ubuntu.22.04.amd64
@@ -1,0 +1,109 @@
+# syntax=docker/dockerfile:experimental
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LC_ALL=C LANGUAGE=C LANG=C
+
+ENV OS_NAME=Ubuntu
+ENV OS_VERSION=22.04
+ENV OS_ARCH=x86_64
+ENV ARTIFACTORY_URL="https://pdx-artifacts.rad.ubnt.com"
+
+ARG HOST_UID=1002
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    useradd -u $HOST_UID --create-home --shell /bin/bash ubnt
+
+RUN \
+    sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' && \
+    sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g' && \
+    echo "ubnt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "ubnt user:";  su - ubnt -c id
+
+RUN dpkg --configure -a
+
+RUN apt-get update && apt-get install -qy apt-utils gnupg2
+
+RUN printf "installing packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-utils \
+    autoconf \
+    automake \
+    binfmt-support \
+    build-essential \
+    curl \
+    fakeroot \
+    procps \
+    git \
+    gnupg2 \
+    wget
+
+RUN printf "installing dev packages...\n" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsystemd-dev \
+    libbluetooth-dev \
+    libudev-dev
+
+RUN printf "installing python...\n" && \
+    apt-get update && apt-get install -y --no-install-recommends python2.7 && \
+    ln -sf /usr/bin/python2.7 /usr/bin/python
+
+RUN apt-get install -y --no-install-recommends \
+	jq \
+	lsb-release \
+	sshpass \
+	pkg-config
+
+RUN apt-get install -y --no-install-recommends \
+	bc \
+	bzip2 \
+	ca-certificates \
+	cpio \
+	file \
+	git \
+	gzip \
+	libncurses5-dev \
+	make \
+	openssh-client \
+	python3 \
+	rsync \
+	unzip \
+	wget \
+	asciidoc \
+	cmake \
+	lzip \
+	tar \
+	xz-utils \
+	eatmydata \
+	uidmap \
+	xxd \
+	vim \
+	ninja-build \
+	curl \
+	autoconf \
+	autotools-dev \
+	sudo \
+	automake \
+	libtool \
+	ant \
+	openjdk-17-jdk \
+	nasm \
+	tree \
+	pip \
+	python-setuptools
+
+RUN wget https://releases.jfrog.io/artifactory/jfrog-cli/v2/[RELEASE]/jfrog-cli-linux-amd64/jfrog -O /usr/local/bin/jfrog && sudo chmod a+x /usr/local/bin/jfrog
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+WORKDIR /build
+USER ubnt
+ENV HOME=/home/ubnt
+RUN printf "installing nvm...\n" && \
+	curl https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash
+ENV NVM_DIR="$HOME/.nvm"
+RUN \. "$NVM_DIR/nvm.sh" && \. "$NVM_DIR/bash_completion"
+ENV NVM_ENV_SH=$HOME/.nvm/nvm.sh


### PR DESCRIPTION
## Description :
- Jenkins can not build macOS and iOS framework.
- Jenkins can not build Debian arm64/x86_64 , Ubuntu x86_64, Android .

## After this PR :
- Jenkins can build macOS and iOS framework.
- Upload all platform module and debug Symbol to  artifact server (jfrog).
- Jenkins can build Debian arm64/x86_64 , Ubuntu x86_64, Android by Docker.
- All Platform use TAG_NAME to build.
- Support Parallel Jenkins  Node build module.

## Related PR :
None

# TBD :
None

<img width="1652" alt="jenkinsbuildwebrtc" src="https://github.com/ubiquiti/ubnt_libjingle/assets/84304140/fd02b757-66e0-43c4-8318-74e60abfdb73">
