### PR TITLE
fix: [UPC-5751] Google WebRTC lib crash on Protect android app

### DIFF
--- a/rtc_base/network.cc
+++ b/rtc_base/network.cc
@@ -965,12 +965,7 @@ bool BasicNetworkManager::IsIgnoredNetwork(const Network& network) const {
     return true;
   }
 #endif
-// UI Customization Begin
-  if (network_monitor_ &&
-      !network_monitor_->IsAdapterAvailable(network.name())) {
-    return true;
-  }
-// UI Customization End
+
   // Ignore any networks with a 0.x.y.z IP
   if (network.prefix().family() == AF_INET) {
     return (network.prefix().v4AddressAsHostOrderInteger() < 0x01000000);

--- a/rtc_base/network_monitor.h
+++ b/rtc_base/network_monitor.h
@@ -122,20 +122,7 @@ class NetworkMonitorInterface {
   void SetNetworksChangedCallback(std::function<void()> callback) {
     networks_changed_callback_ = std::move(callback);
   }
-// UI Customization Begin
-  // Is this interface available to use? WebRTC shouldn't attempt to use it if
-  // this returns false.
-  //
-  // It's possible for this status to change, in which case
-  // SignalNetworksChanged will be fired.
-  //
-  // These specific use case this was added for was a phone with two SIM cards,
-  // where attempting to use all interfaces returned from getifaddrs caused the
-  // connection to be dropped.
-  virtual bool IsAdapterAvailable(absl::string_view interface_name) {
-    return true;
-  }
-// UI Customization End
+
  protected:
   void InvokeNetworksChangedCallback() {
     if (networks_changed_callback_) {

--- a/sdk/android/src/jni/android_network_monitor.h
+++ b/sdk/android/src/jni/android_network_monitor.h
@@ -92,9 +92,7 @@ class AndroidNetworkMonitor : public rtc::NetworkMonitorInterface {
       int socket_fd,
       const rtc::IPAddress& address,
       absl::string_view if_name) override;
-// UI Customization Begin
-  bool IsAdapterAvailable(absl::string_view if_name) override;
-// UI Customization End
+
   InterfaceInfo GetInterfaceInfo(absl::string_view if_name) override;
 
   // Always expected to be called on the network thread.
@@ -139,12 +137,6 @@ class AndroidNetworkMonitor : public rtc::NetworkMonitorInterface {
   ScopedJavaGlobalRef<jobject> j_network_monitor_;
   rtc::Thread* const network_thread_;
   bool started_ RTC_GUARDED_BY(network_thread_) = false;
-// UI Customization Begin
-  std::map<std::string, rtc::AdapterType, rtc::AbslStringViewCmp>
-      adapter_type_by_name_ RTC_GUARDED_BY(network_thread_);
-  std::map<std::string, rtc::AdapterType, rtc::AbslStringViewCmp>
-      vpn_underlying_adapter_type_by_name_ RTC_GUARDED_BY(network_thread_);
-// UI Customization End
   std::map<std::string, NetworkHandle, rtc::AbslStringViewCmp>
       network_handle_by_if_name_ RTC_GUARDED_BY(network_thread_);
   std::map<rtc::IPAddress, NetworkHandle> network_handle_by_address_

--- a/sdk/objc/native/src/objc_network_monitor.h
+++ b/sdk/objc/native/src/objc_network_monitor.h
@@ -46,9 +46,7 @@ class ObjCNetworkMonitor : public rtc::NetworkMonitorInterface,
   void Stop() override;
 
   InterfaceInfo GetInterfaceInfo(absl::string_view interface_name) override;
-// UI Customization Begin
-  bool IsAdapterAvailable(absl::string_view interface_name) override;
-// UI Customization End
+
   // NetworkMonitorObserver override.
   // Fans out updates to observers on the correct thread.
   void OnPathUpdate(

--- a/sdk/objc/native/src/objc_network_monitor.mm
+++ b/sdk/objc/native/src/objc_network_monitor.mm
@@ -81,17 +81,7 @@ rtc::NetworkMonitorInterface::InterfaceInfo ObjCNetworkMonitor::GetInterfaceInfo
       .available = true,
   };
 }
-// UI Customization Begin
-bool ObjCNetworkMonitor::IsAdapterAvailable(absl::string_view interface_name) {
-  RTC_DCHECK_RUN_ON(thread_);
-  if (adapter_type_by_name_.empty()) {
-    // If we have no path update, assume everything's available, because it's
-    // preferable for WebRTC to try all interfaces rather than none at all.
-    return true;
-  }
-  return adapter_type_by_name_.find(interface_name) != adapter_type_by_name_.end();
-}
-// UI Customization End
+
 void ObjCNetworkMonitor::OnPathUpdate(
     std::map<std::string, rtc::AdapterType, rtc::AbslStringViewCmp> adapter_type_by_name) {
   RTC_DCHECK(network_monitor_ != nil);


### PR DESCRIPTION
[Ticket](https://ubiquiti.atlassian.net/browse/UPC-5751)

After tracing code back to Google WebRTC [M103](https://webrtc.googlesource.com/src.git/+/0a3d3093dfe54af40bbcb9354fe5661386cd6e48/sdk/android/src/jni/android_network_monitor.cc#429), the codes removed in this PR were made and deprecated by Google, so remove them.