### PR TITLE
fix  ios_device_name Undefined identifier on macOS Platform

### DIFF
--- a/Jenkinsfile.pdx
+++ b/Jenkinsfile.pdx
@@ -216,22 +216,6 @@ pipeline {
                         }
                     }
                 }
-                                    
-                stage('MacOS Build') {
-                    stages {
-                        stage('MacOS Library') {
-                            steps {
-                                node(label: 'rix-macos-amd64') {
-                                    deleteDir()
-                                    unstash 'workspace'
-                                    script {
-                                        sh label: 'build', script: "${doMacOSBuild}"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
                 
             }
         }

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -620,19 +620,17 @@ if (is_ios || is_mac) {
         ":videoframebuffer_objc",
       ]
 # UI Customization Begin
-    if (is_ios) {
-      if (ios_device_name != "appletv") {
+      if (is_ios && ios_device_name != "appletv") {
         deps += [
           ":metal_objc",
         ]
       }
-    }
 
-    if (is_mac) {
-      deps += [
-        ":metal_objc",
-      ]
-    }
+      if (is_mac) {
+        deps += [
+          ":metal_objc",
+        ]
+      }
 # UI Customization End
     }
 
@@ -706,15 +704,13 @@ if (is_ios || is_mac) {
         "objc/components/capturer/RTCFileVideoCapturer.m",
       ]
 # UI Customization Begin
-      if(is_ios) {
-        if (ios_device_name != "appletv") {
-          sources += [
-              "objc/components/capturer/RTCCameraVideoCapturer.h",
-              "objc/components/capturer/RTCCameraVideoCapturer.m",
-          ]
-        }
+      if (is_ios && ios_device_name != "appletv") {
+        sources += [
+          "objc/components/capturer/RTCCameraVideoCapturer.h",
+          "objc/components/capturer/RTCCameraVideoCapturer.m",
+        ]
       }
-      
+
       if (is_mac) {
         sources += [
             "objc/components/capturer/RTCCameraVideoCapturer.h",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -620,11 +620,19 @@ if (is_ios || is_mac) {
         ":videoframebuffer_objc",
       ]
 # UI Customization Begin
-      if(ios_device_name != "appletv") {
+    if (is_ios) {
+      if (ios_device_name != "appletv") {
         deps += [
           ":metal_objc",
         ]
       }
+    }
+
+    if (is_mac) {
+      deps += [
+        ":metal_objc",
+      ]
+    }
 # UI Customization End
     }
 
@@ -698,11 +706,13 @@ if (is_ios || is_mac) {
         "objc/components/capturer/RTCFileVideoCapturer.m",
       ]
 # UI Customization Begin
-      if (ios_device_name != "appletv") {
-        sources += [
-            "objc/components/capturer/RTCCameraVideoCapturer.h",
-            "objc/components/capturer/RTCCameraVideoCapturer.m",
-        ]
+      if(is_ios) {
+        if (ios_device_name != "appletv") {
+          sources += [
+              "objc/components/capturer/RTCCameraVideoCapturer.h",
+              "objc/components/capturer/RTCCameraVideoCapturer.m",
+          ]
+        }
       }
       
       if (is_mac) {


### PR DESCRIPTION
# ticket : Google WebRTC lib for macOS project
# [UPC-5885](https://ubiquiti.atlassian.net/browse/UPC-5885)

ERROR at
- sdk/BUILD.gn:623:10:
- sdk/BUILD.gn:709:11:

<img width="1527" alt="Screenshot 2023-08-30 at 4 04 00 PM" src="https://github.com/ubiquiti/ubnt_libjingle/assets/84304140/6173b6e5-fa50-4ea1-8945-ac6031938e5f">



[UPC-5885]: https://ubiquiti.atlassian.net/browse/UPC-5885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ