### PR TITLE
fix: Datachannel closing issue on WebUI

### DIFF
--- a/net/dcsctp/socket/stream_reset_handler.cc
+++ b/net/dcsctp/socket/stream_reset_handler.cc
@@ -261,10 +261,10 @@ void StreamResetHandler::HandleResponse(const ParameterDescriptor& descriptor) {
         // was stream need to be reset, so it sends an outgoing request after responding, 
         // thus when console receiving this outgoing request from app, it will close the 
         // stream which just opened a while ago - then playback 3-dots.
-#ifndef UI_CUSTOMIZATION
+// #ifndef UI_CUSTOMIZATION
         // Force this request to be sent again, but with new req_seq_nbr.
         current_request_->PrepareRetransmission();
-#endif
+// #endif
 // UI Customization End
         reconfig_timer_->set_duration(ctx_->current_rto());
         reconfig_timer_->Start();


### PR DESCRIPTION
Remove our customization to fix the data channel closing issue on WebUI.