### PR TITLE
fix: Ubuntu 22.04 docker issue

### DIFF
--- a/Jenkinsfile.pdx
+++ b/Jenkinsfile.pdx
@@ -110,17 +110,17 @@ pipeline {
                 parallel(
                     'docker:arm64': {
                         script {
-                            DOCKER_ARM64 = docker.build("${APP}_arm64:${HASH}", "--pull -f ./docker/Dockerfile.debian.11.arm64 ./docker")
+                            DOCKER_ARM64 = docker.build("${APP}_arm64:${HASH}", "--progress=plain --pull -f ./docker/Dockerfile.debian.11.arm64 ./docker")
                         }
                     },
                     'docker:amd64': {
                         script {
-                            DOCKER_AMD64 = docker.build("${APP}_amd64:${HASH}", "--pull -f ./docker/Dockerfile.debian.11.amd64 ./docker")
+                            DOCKER_AMD64 = docker.build("${APP}_amd64:${HASH}", "--progress=plain --pull -f ./docker/Dockerfile.debian.11.amd64 ./docker")
                         }
                     },
                     'docker:ubuntu_22_04_amd64': {
                         script {
-                            DOCKER_UBUNTU_22_04_AMD64 = docker.build("${APP}_ubuntu_22_04_amd64:${HASH}", "--pull -f ./docker/Dockerfile.ubuntu.22.04.amd64 ./docker")
+                            DOCKER_UBUNTU_22_04_AMD64 = docker.build("${APP}_ubuntu_22_04_amd64:${HASH}", "--progress=plain --pull -f ./docker/Dockerfile.ubuntu.22.04.amd64 ./docker")
                         }
                     }
                 )

--- a/docker/Dockerfile.ubuntu.22.04.amd64
+++ b/docker/Dockerfile.ubuntu.22.04.amd64
@@ -30,72 +30,63 @@ RUN apt-get update && apt-get install -qy apt-utils gnupg2
 RUN printf "installing packages...\n" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    apt-utils \
-    autoconf \
-    automake \
-    binfmt-support \
-    build-essential \
-    curl \
-    fakeroot \
-    procps \
-    git \
-    gnupg2 \
-    wget
-
-RUN printf "installing dev packages...\n" && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libsystemd-dev \
-    libbluetooth-dev \
-    libudev-dev
-
-RUN printf "installing python...\n" && \
-    apt-get update && apt-get install -y --no-install-recommends python2.7 && \
-    ln -sf /usr/bin/python2.7 /usr/bin/python
-
-RUN apt-get install -y --no-install-recommends \
-	jq \
-	lsb-release \
-	sshpass \
-	pkg-config
-
-RUN apt-get install -y --no-install-recommends \
-	bc \
-	bzip2 \
-	ca-certificates \
-	cpio \
-	file \
-	git \
-	gzip \
-	libncurses5-dev \
-	make \
-	openssh-client \
-	python3 \
-	rsync \
-	unzip \
-	wget \
-	asciidoc \
-	cmake \
-	lzip \
-	tar \
-	xz-utils \
-	eatmydata \
-	uidmap \
-	xxd \
-	vim \
-	ninja-build \
-	curl \
-	autoconf \
-	autotools-dev \
-	sudo \
-	automake \
-	libtool \
-	ant \
-	openjdk-17-jdk \
-	nasm \
-	tree \
-	pip \
-	python-setuptools
+    apt-utils
+RUN apt-get install -y --no-install-recommends autoconf
+RUN apt-get install -y --no-install-recommends automake
+RUN apt-get install -y --no-install-recommends binfmt-support
+RUN apt-get install -y --no-install-recommends build-essential
+RUN apt-get install -y --no-install-recommends curl
+RUN apt-get install -y --no-install-recommends fakeroot
+RUN apt-get install -y --no-install-recommends procps
+RUN apt-get install -y --no-install-recommends git
+RUN apt-get install -y --no-install-recommends gnupg2
+RUN apt-get install -y --no-install-recommends wget
+RUN apt-get install -y --no-install-recommends libsystemd-dev
+RUN apt-get install -y --no-install-recommends libbluetooth-dev
+RUN apt-get install -y --no-install-recommends libudev-dev
+RUN apt-get install -y --no-install-recommends python2.7 && ln -sf /usr/bin/python2.7 /usr/bin/python
+RUN apt-get install -y --no-install-recommends jq
+RUN apt-get install -y --no-install-recommends lsb-release
+RUN apt-get install -y --no-install-recommends sshpass
+RUN apt-get install -y --no-install-recommends pkg-config
+RUN apt-get install -y --no-install-recommends bc
+RUN apt-get install -y --no-install-recommends bzip2
+RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends cpio
+RUN apt-get install -y --no-install-recommends file
+RUN apt-get install -y --no-install-recommends git
+RUN apt-get install -y --no-install-recommends gzip
+RUN apt-get install -y --no-install-recommends libncurses5-dev
+RUN apt-get install -y --no-install-recommends make
+RUN apt-get install -y --no-install-recommends openssh-client
+RUN apt-get install -y --no-install-recommends python3
+RUN apt-get install -y --no-install-recommends rsync
+RUN apt-get install -y --no-install-recommends unzip
+RUN apt-get install -y --no-install-recommends wget
+RUN apt-get install -y --no-install-recommends asciidoc
+RUN apt-get install -y --no-install-recommends cmake
+RUN apt-get install -y --no-install-recommends lzip 
+RUN apt-get install -y --no-install-recommends tar 
+RUN apt-get install -y --no-install-recommends xz-utils 
+RUN apt-get install -y --no-install-recommends eatmydata 
+RUN apt-get install -y --no-install-recommends uidmap 
+RUN apt-get install -y --no-install-recommends xxd
+RUN apt-get install -y --no-install-recommends vim
+RUN apt-get install -y --no-install-recommends ninja-build
+RUN apt-get install -y --no-install-recommends curl
+RUN apt-get install -y --no-install-recommends autoconf
+RUN apt-get install -y --no-install-recommends autotools-dev
+RUN apt-get install -y --no-install-recommends sudo
+RUN apt-get install -y --no-install-recommends automake
+RUN apt-get install -y --no-install-recommends libtool
+RUN apt-get install -y --no-install-recommends ant
+RUN apt-get install -y --no-install-recommends openjdk-17-jdk
+RUN apt-get install -y --no-install-recommends nasm
+RUN apt-get install -y --no-install-recommends tree
+RUN apt-get install -y --no-install-recommends nasm
+RUN apt-get install -y --no-install-recommends tree
+RUN apt-get install -y --no-install-recommends pip
+RUN apt-get install -y --no-install-recommends python-setuptools
 
 RUN wget https://releases.jfrog.io/artifactory/jfrog-cli/v2/[RELEASE]/jfrog-cli-linux-amd64/jfrog -O /usr/local/bin/jfrog && sudo chmod a+x /usr/local/bin/jfrog
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
### Description

Looks like all that was needed is to regenerate docker image.
Added changes to make it easier to detect which dependency is failing to install