### PR TITLE
fix: tvOS should not include the video capture framework

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -280,19 +280,16 @@ if (is_ios || is_mac) {
           #":metal_objc",
 # UI Customization End
           ":opengl_objc",
-          ":videocapture_objc",
+# UI Customization Begin
+          # ":videocapture_objc",
+# UI Customization End
           ":videoframebuffer_objc",
         ]
 # UI Customization Begin
-        if (is_ios && ios_device_name != "appletv") {
+        if (ios_device_name != "appletv") {
           deps += [
             ":metal_objc",
-          ]
-        }
-
-        if (is_mac) {
-          deps += [
-            ":metal_objc",
+            ":videocapture_objc",
           ]
         }
 # UI Customization End
@@ -693,17 +690,10 @@ if (is_ios || is_mac) {
         "objc/components/capturer/RTCFileVideoCapturer.m",
       ]
 # UI Customization Begin
-      if (is_ios && ios_device_name != "appletv") {
+      if ((is_ios || is_mac) && ios_device_name != "appletv") {
         sources += [
           "objc/components/capturer/RTCCameraVideoCapturer.h",
           "objc/components/capturer/RTCCameraVideoCapturer.m",
-        ]
-      }
-
-      if (is_mac) {
-        sources += [
-            "objc/components/capturer/RTCCameraVideoCapturer.h",
-            "objc/components/capturer/RTCCameraVideoCapturer.m",
         ]
       }
 # UI Customization End
@@ -1387,7 +1377,7 @@ if (is_ios || is_mac) {
           "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.h",
         ]
 # UI Customization Begin
-        if(ios_device_name == "iphone") {
+        if (ios_device_name == "iphone") {
           common_objc_headers += [
             "objc/components/renderer/metal/RTCMTLVideoView.h",
             "objc/components/capturer/RTCCameraVideoCapturer.h",
@@ -1423,7 +1413,7 @@ if (is_ios || is_mac) {
           ":peerconnectionfactory_base_objc",
 # UI Customization Begin
           #":videocapture_objc",
-# UI Customization Begin
+# UI Customization End
           ":videocodec_objc",
           ":videotoolbox_objc",
         ]

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -690,7 +690,13 @@ if (is_ios || is_mac) {
         "objc/components/capturer/RTCFileVideoCapturer.m",
       ]
 # UI Customization Begin
-      if ((is_ios || is_mac) && ios_device_name != "appletv") {
+      if (is_ios && ios_device_name != "appletv") {
+        sources += [
+          "objc/components/capturer/RTCCameraVideoCapturer.h",
+          "objc/components/capturer/RTCCameraVideoCapturer.m",
+        ]
+      }
+      if (is_mac) {
         sources += [
           "objc/components/capturer/RTCCameraVideoCapturer.h",
           "objc/components/capturer/RTCCameraVideoCapturer.m",

--- a/sdk/objc/components/audio/RTCAudioProcessing.h
+++ b/sdk/objc/components/audio/RTCAudioProcessing.h
@@ -9,8 +9,6 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 
 - (void)initialize:(int)sample_rate_hz channels:(int)num_channels;
 
-- (void)process:(const float*)data;
-
 - (void)updateAudioIndicator:(int)average peak:(int)peak;
 
 @end

--- a/sdk/objc/native/src/unifi_capture_post_processing.mm
+++ b/sdk/objc/native/src/unifi_capture_post_processing.mm
@@ -20,7 +20,6 @@ void UnifiCapturePostProcessing::Initialize(int sample_rate_hz, int num_channels
 }
 
 void UnifiCapturePostProcessing::Process(AudioBuffer* audio) {
-  [audio_processing_ process:audio->channels()[0]];
 }
 
 std::string UnifiCapturePostProcessing::ToString() const {


### PR DESCRIPTION
1. tvOS build script should not include the video capture framework.
2. Remove unnecessary method for iOS app.