### PR TITLE
fix: [UP-1039] iOS audio volume will be lowered when using data channel talkback with media live stream

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
+++ b/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
@@ -49,7 +49,7 @@
   // everything we can.
   NSError *error = nil;
 
-  if (self.category != AVAudioSessionCategoryPlayAndRecord || self.mode != configuration.mode ||
+  if (self.category != configuration.category || self.mode != configuration.mode ||
       self.categoryOptions != configuration.categoryOptions) {
     NSError *configuringError = nil;
     if (![self setCategory:configuration.category

--- a/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
+++ b/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
@@ -49,7 +49,7 @@
   // everything we can.
   NSError *error = nil;
 
-  if (self.category != configuration.category || self.mode != configuration.mode ||
+  if (self.category != AVAudioSessionCategoryPlayAndRecord || self.mode != configuration.mode ||
       self.categoryOptions != configuration.categoryOptions) {
     NSError *configuringError = nil;
     if (![self setCategory:configuration.category

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -82,6 +82,7 @@ RTC_OBJC_EXPORT
 // UI Customization Begin
 - (void)audioSession:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession
     didChangeMicrophoneMuted:(BOOL)isMicrophoneMuted;
+- (void)audioSessionDidChangeOutScope:(RTC_OBJC_TYPE(RTCAudioSession) *)session;
 // UI Customization End
 
 /** Called when the audio device detects a playout glitch. The argument is the
@@ -219,6 +220,9 @@ RTC_OBJC_EXPORT
 - (void)lockForConfiguration;
 /** Relinquishes exclusive access to the audio session. */
 - (void)unlockForConfiguration;
+
+// UI customization
+- (void)notifyDidChangeOutScope;
 
 /** If `active`, activates the audio session if it isn't already active.
  *  Successful calls must be balanced with a setActive:NO when activation is no

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -223,6 +223,15 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
     }
   }
 }
+
+- (void)notifyDidChangeOutScope {
+  for (auto delegate : self.delegates) {
+    SEL sel = @selector(audioSessionDidChangeOutScope:);
+    if ([delegate respondsToSelector:sel]) {
+      [delegate audioSessionDidChangeOutScope:self];
+    }
+  }
+}
 // UI Customization End
 
 - (void)setIgnoresPreferredAttributeConfigurationErrors:

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -91,5 +91,8 @@
     didChangeMicrophoneMuted:(BOOL)isMicrophoneMuted {
   _observer->OnMicrophoneMutedChange(isMicrophoneMuted);
 }
+- (void)audioSessionDidChangeOutScope:(RTC_OBJC_TYPE(RTCAudioSession) *)session {
+  _observer->OnOutScopeChange();
+}
 // UI Customization End
 @end

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -148,6 +148,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void OnCanPlayOrRecordChange(bool can_play_or_record) override;
   void OnChangedOutputVolume() override;
   // UI Customization Begin
+  void OnOutScopeChange() override;
   void OnMicrophoneMutedChange(bool is_microphone_muted) override;
   // UI Customization End
 
@@ -175,6 +176,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void HandlePlayoutGlitchDetected();
   void HandleOutputVolumeChange();
   // UI Customization Begin
+  void HandleOutScopeChange();
   void HandleMicrophoneMutedChange(bool is_microphone_muted);
   // UI Customization End
 

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -376,6 +376,11 @@ void AudioDeviceIOS::OnChangedOutputVolume() {
 }
 
 // UI Customization Begin
+void AudioDeviceIOS::OnOutScopeChange() {
+  RTC_DCHECK(thread_);
+  thread_->PostTask(SafeTask(safety_, [this] { HandleOutScopeChange(); }));
+}
+
 void AudioDeviceIOS::OnMicrophoneMutedChange(bool is_microphone_muted) {
   RTC_DCHECK(thread_);
   thread_->PostTask(SafeTask(safety_, [this, is_microphone_muted] { HandleMicrophoneMutedChange(is_microphone_muted); }));
@@ -658,6 +663,15 @@ void AudioDeviceIOS::HandleOutputVolumeChange() {
 }
 
 // UI Customization Begin
+void AudioDeviceIOS::HandleOutScopeChange() {
+  RTC_DCHECK_RUN_ON(thread_);
+  RTCLog(@"Handling OutScope changed");
+  StopRecording();
+  StopPlayout();
+  InitPlayout();
+  StartPlayout();
+}
+
 void AudioDeviceIOS::HandleMicrophoneMutedChange(bool is_microphone_muted) {
   RTC_DCHECK_RUN_ON(thread_);
   RTCLog(@"Handling MicrophoneMuted change to %d", is_microphone_muted);

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -666,10 +666,13 @@ void AudioDeviceIOS::HandleOutputVolumeChange() {
 void AudioDeviceIOS::HandleOutScopeChange() {
   RTC_DCHECK_RUN_ON(thread_);
   RTCLog(@"Handling OutScope changed");
-  StopRecording();
-  StopPlayout();
-  InitPlayout();
-  StartPlayout();
+  RTCAudioSessionConfiguration* webRTCConfiguration = [RTCAudioSessionConfiguration webRTCConfiguration];
+  if (!webRTCConfiguration.isMicrophoneEnabled) {
+    StopRecording();
+    StopPlayout();
+    InitPlayout();
+    StartPlayout();
+  }
 }
 
 void AudioDeviceIOS::HandleMicrophoneMutedChange(bool is_microphone_muted) {

--- a/sdk/objc/native/src/audio/audio_session_observer.h
+++ b/sdk/objc/native/src/audio/audio_session_observer.h
@@ -33,6 +33,7 @@ class AudioSessionObserver {
   virtual void OnChangedOutputVolume() = 0;
 
 // UI Customization Begin
+  virtual void OnOutScopeChange() = 0;
   virtual void OnMicrophoneMutedChange(bool is_microphone_muted) = 0;
 // UI Customization End
  protected:

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -96,10 +96,10 @@ bool VoiceProcessingAudioUnit::Init() {
   AudioComponentDescription vpio_unit_description;
   vpio_unit_description.componentType = kAudioUnitType_Output;
 // UI Customization Begin
-  if (webRTCConfiguration.isMicrophoneEnabled)
+  // if (webRTCConfiguration.isMicrophoneEnabled)
     vpio_unit_description.componentSubType = kAudioUnitSubType_VoiceProcessingIO;
-  else
-    vpio_unit_description.componentSubType = kAudioUnitSubType_RemoteIO;
+  // else
+    // vpio_unit_description.componentSubType = kAudioUnitSubType_RemoteIO;
   // vpio_unit_description.componentSubType = kAudioUnitSubType_VoiceProcessingIO;
 // UI Customization End
   vpio_unit_description.componentManufacturer = kAudioUnitManufacturer_Apple;

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -96,10 +96,10 @@ bool VoiceProcessingAudioUnit::Init() {
   AudioComponentDescription vpio_unit_description;
   vpio_unit_description.componentType = kAudioUnitType_Output;
 // UI Customization Begin
-  // if (webRTCConfiguration.isMicrophoneEnabled)
+  if (webRTCConfiguration.isMicrophoneEnabled || webRTCConfiguration.category == AVAudioSessionCategoryPlayAndRecord)
     vpio_unit_description.componentSubType = kAudioUnitSubType_VoiceProcessingIO;
-  // else
-    // vpio_unit_description.componentSubType = kAudioUnitSubType_RemoteIO;
+  else
+    vpio_unit_description.componentSubType = kAudioUnitSubType_RemoteIO;
   // vpio_unit_description.componentSubType = kAudioUnitSubType_VoiceProcessingIO;
 // UI Customization End
   vpio_unit_description.componentManufacturer = kAudioUnitManufacturer_Apple;


### PR DESCRIPTION
[Ticket](https://ubiquiti.atlassian.net/browse/UP-1039)

**Description**
Issue is caused by the component sub type in webrtc lib is not aligned with app.
- App uses AudioRecorder and set the sub type to VPIO for mic audio data capture.
- WebRTC lib creates audio playout unit with sub type RemoteIO.

**Solution**
Make it aligned, when app switching the audio category, notify webrtc lib to re-create the audio playout unit with the right type.